### PR TITLE
Fixing B475E audio BSP. Credit for the fix goes to @janjongboom from EI.

### DIFF
--- a/Drivers/BSP/B-L475E-IOT01/stm32l475e_iot01_errno.h
+++ b/Drivers/BSP/B-L475E-IOT01/stm32l475e_iot01_errno.h
@@ -55,6 +55,10 @@
 #define BSP_ERROR_BUS_CRC_ERROR              -106
 #define BSP_ERROR_BUS_DMA_FAILURE            -107
 
+#ifdef __cplusplus
+ }
+#endif
+
 #endif /* STM32L475E_IOT01_ERRNO_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
Fixes v2 BSP compilation issue. 

Credit goes to @janjongboom from code in:
https://github.com/edgeimpulse/firmware-st-b-l475e-iot01a/blob/master/MP34DT01/stm32l475e_iot01_errno.h

